### PR TITLE
use babel-watch instead of babel-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "babel-watch": "^2.0.7",
     "babelify": "^8.0.0",
     "bootstrap": "^4.0.0",
     "browserify-middleware": "^8.0.0",

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 [ -f .env ] && source .env
-babel-node src/cli.js $@
+babel-watch --extensions .js,.pug,.yaml --watch src --watch views --watch . src/cli.js $@


### PR DESCRIPTION
babel-watch re-builds the application if source files change. This is usefull during development but also during production.